### PR TITLE
GLIBC missing after upgrade

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build native API function
-        run: ./gradlew image-picker-api:clean :image-picker-api:build -Dquarkus.package.type=native -x test -Dquarkus.native.resources.includes=application.properties -Dquarkus.native.container-build=true --info
+        run: ./gradlew image-picker-api:clean :image-picker-api:build -Dquarkus.package.type=native -x test -Dquarkus.native.resources.includes=application.properties -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21 --info
       - name: Build native Image Processor
-        run: ./gradlew :image-processor:clean :image-processor:build -Dquarkus.package.type=native -x test -Dquarkus.native.resources.includes=application.properties -Dquarkus.native.container-build=true --info
+        run: ./gradlew :image-processor:clean :image-processor:build -Dquarkus.package.type=native -x test -Dquarkus.native.resources.includes=application.properties -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21 --info
       - name: Build native Image Cropper
-        run: ./gradlew image-cropper:clean :image-cropper:build -Dquarkus.package.type=native -x test -Dquarkus.native.resources.includes=application.properties -Dquarkus.native.container-build=true --info
+        run: ./gradlew image-cropper:clean :image-cropper:build -Dquarkus.package.type=native -x test -Dquarkus.native.resources.includes=application.properties -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21 --info
       - name: Upload API function zip
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   build-native:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v3

--- a/.github/workflows/build-push-image-classifier.yml
+++ b/.github/workflows/build-push-image-classifier.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   build-docker-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       image_tag: ${{steps.upload-image.outputs.image_tag}}
       image_path: ${{steps.upload-image.outputs.image_path}}

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build-gradle-project:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v3


### PR DESCRIPTION
fix GitHub runner to Ubuntu 22.04
specify quarkus builder image specifically